### PR TITLE
Fix unit test for sqrt and add no_std support.

### DIFF
--- a/cordic/src/cordic_number.rs
+++ b/cordic/src/cordic_number.rs
@@ -3,7 +3,7 @@ use fixed::types::extra::{
 };
 use fixed::types::U0F64;
 use fixed::{FixedI16, FixedI32, FixedI64, FixedI8};
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Shl, Shr, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, Mul, Neg, Shl, Shr, Sub, SubAssign};
 
 /// A number that can be used by the CORDIC-based algorithms.
 ///

--- a/cordic/src/lib.rs
+++ b/cordic/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
         for i in 0..(1 << 20) {
             let x = I48F16::from_bits(i);
             let fx: f64 = x.to_num();
-            assert_approx_eq(x, sqrt(x, 40).to_num(), fx.sqrt(), 0.01);
+            assert_approx_eq(x, sqrt(x).to_num(), fx.sqrt(), 0.01);
         }
     }
 

--- a/cordic/src/lib.rs
+++ b/cordic/src/lib.rs
@@ -1,10 +1,17 @@
 //! Implementations of special functions based on the CORDIC algorithm.
 
+#![no_std]
+
+// Used to make the tests build and run.
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
 mod cordic_number;
 
 pub use cordic_number::CordicNumber;
 use fixed::types::U0F64;
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 const ATAN_TABLE: &[u8] = include_bytes!("tables/cordic_atan.table");
 const EXP_MINUS_ONE_TABLE: &[u8] = include_bytes!("tables/cordic_exp_minus_one.table");
@@ -233,7 +240,7 @@ mod tests {
     use super::*;
     use fixed::types::I48F16;
 
-    fn assert_approx_eq<T: std::fmt::Display>(
+    fn assert_approx_eq<T: core::fmt::Display>(
         input: T,
         computed: f64,
         expected: f64,


### PR DESCRIPTION
I needed the tests working so I could be confident I didn't break anything, and no_std support is really nice for embedded development.