### PR TITLE
Fix sqrt overflow panic on high bit values

### DIFF
--- a/cordic/src/lib.rs
+++ b/cordic/src/lib.rs
@@ -202,7 +202,7 @@ pub fn exp<T: CordicNumber>(x: T) -> T {
 
 /// Compute the square root of the given fixed-point number.
 pub fn sqrt<T: CordicNumber + Fixed>(x: T) -> T {
-    if x == T::zero() || x == T::one() {
+    if x == <T as CordicNumber>::zero() || x == T::one() {
         return x;
     }
 


### PR DESCRIPTION
Fixes https://github.com/sebcrozet/cordic/issues/1

__I am not entirely sure I handled overflow correctly__,
but comparing results with known square root values shows that there is not a huge error.